### PR TITLE
Estilo padrão para macOS

### DIFF
--- a/app/calculadora.py
+++ b/app/calculadora.py
@@ -31,21 +31,21 @@ class Calculadora(object):
     def __init__(self, master):
         self.master = master
         self.calc = Calculador()
-        self.style = style.Dark()
+        self.style = style.DefaultStyleForMacOS()
 
         # Edição da Top-Level
         self.master.title('Calculadora Tk')
         self.master.maxsize(width=335, height=355)
         self.master.minsize(width=335, height=355)
         self.master.geometry('-150+100')
-        self.master['bg'] = '#252729'
+        self.master['bg'] = self.style.master_bg
 
         # Área do input
-        self.__frame_input = tk.Frame(self.master, bg='#252729', pady=4)
+        self.__frame_input = tk.Frame(self.master, bg=self.style.frame_bg, pady=4)
         self.__frame_input.pack()
 
         # Área dos botões
-        self.__frame_buttons = tk.Frame(self.master, bg='#252729', padx=2)
+        self.__frame_buttons = tk.Frame(self.master, bg=self.style.frame_bg, padx=2)
         self.__frame_buttons.pack()
 
         # Funções de inicialização 

--- a/app/calculadora.py
+++ b/app/calculadora.py
@@ -5,6 +5,7 @@
 
 # Builtins
 import tkinter as tk
+import platform
 from functools import partial
 
 # Módulos próprios
@@ -31,7 +32,12 @@ class Calculadora(object):
     def __init__(self, master):
         self.master = master
         self.calc = Calculador()
-        self.style = style.DefaultStyleForMacOS()
+
+        # Define estilo padrão para macOS, caso seja o sistema operacional utilizado
+        if platform.system() == 'Darwin':
+            self.style = style.DefaultStyleForMacOS()
+        else:
+            self.style = style.Dark()
 
         # Edição da Top-Level
         self.master.title('Calculadora Tk')

--- a/app/style.py
+++ b/app/style.py
@@ -72,7 +72,6 @@ class DefaultStyleForMacOS(object):
         }
 
         self.BTN_DEFAULT = {
-            'activeforeground': 'light blue',
             'borderwidth': 0,
             'width': 7,
             'height': 3,
@@ -80,7 +79,6 @@ class DefaultStyleForMacOS(object):
         }
 
         self.BTN_NUMERICO = {
-            'activeforeground': 'light blue',
             'borderwidth': 0,
             'width': 7,
             'height': 3,
@@ -88,7 +86,6 @@ class DefaultStyleForMacOS(object):
         }
 
         self.BTN_OPERADOR = {
-            'activeforeground': 'light blue',
             'borderwidth': 0,
             'width': 7,
             'height': 3,
@@ -96,7 +93,6 @@ class DefaultStyleForMacOS(object):
         }
 
         self.BTN_CLEAR = {
-            'activeforeground': 'light blue',
             'borderwidth': 0,
             'width': 7,
             'height': 3,

--- a/app/style.py
+++ b/app/style.py
@@ -2,6 +2,9 @@
 
 class Dark(object):
     def __init__(self):
+        self.master_bg = '#252729'
+        self.frame_bg = '#252729'
+
         self.INPUT = {
             'bg': '#252729',
             'fg': 'white',
@@ -54,3 +57,49 @@ class Dark(object):
             'height': 2,
             'font': 'Arial 14 bold'
         }
+
+class DefaultStyleForMacOS(object):
+    """Classe criada para ambientes macOS para corrigir bug de estilo."""
+    def __init__(self):
+        self.master_bg = ''
+        self.frame_bg = ''
+
+        self.INPUT = {
+            'borderwidth': 0,
+            'width': 15,
+            'font': 'Arial 28 bold',
+            'justify': 'right'
+        }
+
+        self.BTN_DEFAULT = {
+            'activeforeground': 'light blue',
+            'borderwidth': 0,
+            'width': 7,
+            'height': 3,
+            'font': 'Arial 14 bold'
+        }
+
+        self.BTN_NUMERICO = {
+            'activeforeground': 'light blue',
+            'borderwidth': 0,
+            'width': 7,
+            'height': 3,
+            'font': 'Arial 14 bold'
+        }
+
+        self.BTN_OPERADOR = {
+            'activeforeground': 'light blue',
+            'borderwidth': 0,
+            'width': 7,
+            'height': 3,
+            'font': 'Arial 14 bold'
+        }
+
+        self.BTN_CLEAR = {
+            'activeforeground': 'light blue',
+            'borderwidth': 0,
+            'width': 7,
+            'height': 3,
+            'font': 'Arial 14 bold'
+        }
+        


### PR DESCRIPTION
Ei Matheus! Esse PR foi para adicionar o estilo padrão para macOS.

O trecho abaixo checa o sistema operacional e aplica o estilo correspondente.
```python
        # Define estilo padrão para macOS, caso seja o sistema operacional utilizado
        if platform.system() == 'Darwin':
            self.style = style.DefaultStyleForMacOS()
        else:
            self.style = style.Dark()
```

Modifiquei também os valores de background das linhas abaixo para variáveis, assim consegui definir um valor diferente para o estilo do macOS.
```python
self.master['bg'] = self.style.master_bg
self.__frame_input = tk.Frame(self.master, bg=self.style.frame_bg, pady=4)
self.__frame_buttons = tk.Frame(self.master, bg=self.style.frame_bg, padx=2)
```

