### PR TITLE
Corrige bug do salvar

### DIFF
--- a/app/calculadora.py
+++ b/app/calculadora.py
@@ -15,6 +15,8 @@ from functools import partial
 from json import load as json_load
 from json import dump as json_dump
 
+from copy import deepcopy
+
 # Módulos próprios
 from .calculador import Calculador
 
@@ -84,7 +86,7 @@ class Calculadora(object):
         found_theme = None
         for t in list_of_themes:
             if name == t['name']:
-                found_theme = t
+                found_theme= deepcopy(t)
                 break
         
         return found_theme

--- a/app/calculadora.py
+++ b/app/calculadora.py
@@ -86,7 +86,7 @@ class Calculadora(object):
         found_theme = None
         for t in list_of_themes:
             if name == t['name']:
-                found_theme= deepcopy(t)
+                found_theme = deepcopy(t)
                 break
         
         return found_theme


### PR DESCRIPTION
O bug ocorria, basicamente, por conta da alteração dos valores do tema direto nos componentes da json `self.settings` (toda vez que executa `self.theme['XXXXX'].update(self.settings['global'])`). 
Assim, toda a configuração global que deveria ser parte do tema somente durante a execução é salva no arquivo `settings.json`.
A solução adotada foi a cópia de todo o objeto tema que é retornado pela função `_get_theme`.
